### PR TITLE
Annotated SecretRepository with JsonApiExposed(false)

### DIFF
--- a/crnk-example-service/src/main/java/io/crnk/example/service/model/Secret.java
+++ b/crnk-example-service/src/main/java/io/crnk/example/service/model/Secret.java
@@ -10,7 +10,6 @@ import lombok.Data;
  * Login secret for the user. Implemented as nested resource of login.
  */
 @JsonApiResource(type = "secret", nested = true)
-@JsonApiExposed(false) // do not have endpoint on its own, only nested one
 @Data
 public class Secret {
 

--- a/crnk-example-service/src/main/java/io/crnk/example/service/repository/security/SecretRepository.java
+++ b/crnk-example-service/src/main/java/io/crnk/example/service/repository/security/SecretRepository.java
@@ -3,6 +3,7 @@ package io.crnk.example.service.repository.security;
 import io.crnk.core.exception.ForbiddenException;
 import io.crnk.core.queryspec.QuerySpec;
 import io.crnk.core.repository.ResourceRepositoryBase;
+import io.crnk.core.resource.annotations.JsonApiExposed;
 import io.crnk.core.resource.list.ResourceList;
 import io.crnk.example.service.model.Secret;
 import org.springframework.stereotype.Component;
@@ -10,9 +11,10 @@ import org.springframework.stereotype.Component;
 import java.util.UUID;
 
 /**
- * Showcases throwing a forbidden exception.
+ * Only available internally to other repositories
  */
 @Component
+@JsonApiExposed(false) // do not have endpoint on its own, only nested one
 public class SecretRepository extends ResourceRepositoryBase<Secret, UUID> {
 
     public SecretRepository() {


### PR DESCRIPTION
Resolves #20 

Removed JsonApiExposed(false) annotation above Secret and annotated SecretRepository. This annotation should be used only with repository classes. Annotating the resource class has no effect and the API still exposed to the public by CRNK. 